### PR TITLE
Add SALT v2 data reader

### DIFF
--- a/salt_v2/salt.py
+++ b/salt_v2/salt.py
@@ -1,0 +1,100 @@
+'''Utilities for loading SALT v2 format data.'''
+import json
+import datasets
+
+
+def translation_dataset(
+    path,
+    source_language,
+    target_language,
+    allow_target_language_in_source = True,
+    languages_to_include = None):
+    '''Creates a translation dataset from a SALT v2 format source file.
+ 
+    Various translation tasks, such as many-to-one and many-to-many, are catered
+    for by setting `source_language` and `target_language`. For example:
+        
+    `source_language = 'en', target_language = 'lug'`     (English to Luganda)  
+    `source_language = 'many', target_language = 'en'`    (many to English)
+    `source_language = 'ach', target_language = 'many'`   (Acholi to many)
+    `source_language = 'many', target_language = 'many'`  (many to many)
+    `source_language = 'lug', target_language = 'lug'`    (pass-through from
+                                                           monolingual text)
+    
+    Args:
+        path : String containing the path to a .jsonl file.
+        source_language: Either an ISO 639-2 language code (e.g. 'eng', 'lug'),
+            or 'many' for multiple source languages.
+        target_language: Either an ISO 639-2 language code (e.g. 'eng', 'lug'),
+            or 'many' for multiple target languages.
+        allow_target_language_in_source: In the case of many-to-one or
+            many-to-many translation, specifies whether any records may contain
+            the same language code for both source and target. For example, in
+            many-to-English translation, can there be any records with source
+            text also in English (default True).
+        languages_to_include: If non-empty, a list of language codes
+            that can be included in 'many'. Any text not in these languages will
+            be ignored (Optional).
+            
+    Returns:
+        dataset: A datasets.Dataset object with attributes `source`, `target`,
+            `source_language` and `target_language`. The `source_language` and
+            `target_language` attributes are always ISO 639-2 language codes
+            and may vary from record to record, e.g. in the case of
+            many-to-many.
+    '''
+    with open(path) as file:
+        items = file.readlines()
+        items = [json.loads(j)['text'] for j in items]
+
+    dataset = {
+        'source' : [],
+        'target': [],
+        'source_language': [],
+        'target_language': [],
+    }
+
+    for item in items:
+        all_language_codes = set(item.keys())
+
+        if source_language == 'many':
+            source_languages = all_language_codes
+            if languages_to_include:
+                source_languages = (
+                    source_languages.intersection(languages_to_include))            
+        else:
+            source_languages = [source_language]
+
+        if target_language == 'many':
+            target_languages = all_language_codes
+            if languages_to_include:
+                target_languages = (
+                    target_languages.intersection(languages_to_include))            
+        else:
+            target_languages = [target_language]
+
+
+        for row_source_language in source_languages:
+            for row_target_language in target_languages:
+                if (row_source_language == row_target_language
+                    and not allow_target_language_in_source):
+                    continue
+                if row_target_language not in item:
+                    continue
+                if row_source_language not in item:
+                    continue
+
+                dataset['source'].append(item[row_source_language])
+                dataset['target'].append(item[row_target_language])
+                dataset['source_language'].append(row_source_language)
+                dataset['target_language'].append(row_target_language)
+
+    if not len(dataset):
+        raise ValueError('No sentence pairs were found matching the specifications '
+                         f'(path={path}, source_language={source_language}, '
+                         f'target_language={target_language}, '
+                         'allow_target_language_in_source='
+                         f'{allow_target_language_in_source}, '
+                         f'languages_to_include={languages_to_include}).')
+
+    return datasets.Dataset.from_dict(dataset)

--- a/salt_v2/salt_test.py
+++ b/salt_v2/salt_test.py
@@ -1,0 +1,86 @@
+import unittest
+import salt
+import tempfile
+import shutil
+import pandas as pd
+
+class TestDataLoadingMethods(unittest.TestCase):
+  def setUp(self):
+    self.test_dir = tempfile.mkdtemp()
+    self.test_jsonl_path = self.test_dir + '/test.jsonl'
+    
+    with open(self.test_jsonl_path, 'w') as f:
+        f.write(
+          '{"text" : {"lug" : "lug1", "ach" : "ach1", "eng" : "eng1"}}\n'
+          '{"text" : {"lug" : "lug2", "ach" : "ach2", "eng" : "eng2"}}'
+        )
+    
+  def tearDown(self):
+      shutil.rmtree(self.test_dir)
+
+  def test_one_to_one(self):
+      dataset = salt.translation_dataset(
+          path=self.test_jsonl_path,
+          source_language = 'lug',
+          target_language = 'ach')
+      dataset = pd.DataFrame(dataset.to_dict()).to_dict(orient='records')
+      expected = {
+        'source': ['lug1', 'lug2'],
+        'target': ['ach1', 'ach2'],
+        'source_language': ['lug', 'lug'],
+        'target_language': ['ach', 'ach']}
+      expected = pd.DataFrame(expected).to_dict(orient='records')
+      self.assertCountEqual(dataset, expected)
+      
+  def test_one_to_many(self):
+      dataset = salt.translation_dataset(
+          path=self.test_jsonl_path,
+          source_language = 'lug',
+          target_language = 'many')
+      dataset = pd.DataFrame(dataset.to_dict()).to_dict(orient='records')
+      expected = {
+        'source': ['lug1', 'lug1', 'lug1', 'lug2', 'lug2', 'lug2'],
+        'target': ['eng1', 'lug1', 'ach1', 'eng2', 'lug2', 'ach2'],
+        'source_language': ['lug', 'lug', 'lug', 'lug', 'lug', 'lug'],
+        'target_language': ['eng', 'lug', 'ach', 'eng', 'lug', 'ach']}
+      expected = pd.DataFrame(expected).to_dict(orient='records')
+      self.assertCountEqual(dataset, expected)
+
+  def test_many_to_one(self):
+      dataset = salt.translation_dataset(
+          path=self.test_jsonl_path,
+          source_language = 'many',
+          target_language = 'eng')
+      dataset = pd.DataFrame(dataset.to_dict()).to_dict(orient='records')
+      expected = {
+        'source': ['eng1', 'lug1', 'ach1', 'eng2', 'lug2', 'ach2'],
+        'target': ['eng1', 'eng1', 'eng1', 'eng2', 'eng2', 'eng2'], 
+        'source_language': ['eng', 'lug', 'ach', 'eng', 'lug', 'ach'], 
+        'target_language': ['eng', 'eng', 'eng', 'eng', 'eng', 'eng']}
+      expected = pd.DataFrame(expected).to_dict(orient='records')
+      self.assertCountEqual(dataset, expected)
+
+  def test_many_to_many(self):
+      dataset = salt.translation_dataset(
+          path=self.test_jsonl_path,
+          source_language = 'many',
+          target_language = 'many')
+      dataset = pd.DataFrame(dataset.to_dict()).to_dict(orient='records')
+      expected = {
+        'source': ['lug1', 'lug1', 'lug1', 'ach1', 'ach1', 'ach1',
+                   'eng1', 'eng1', 'eng1', 'lug2', 'lug2', 'lug2',
+                   'ach2', 'ach2', 'ach2', 'eng2', 'eng2', 'eng2'], 
+        'target': ['lug1', 'ach1', 'eng1', 'lug1', 'ach1', 'eng1',
+                   'lug1', 'ach1', 'eng1', 'lug2', 'ach2', 'eng2',
+                   'lug2', 'ach2', 'eng2', 'lug2', 'ach2', 'eng2'], 
+        'source_language': ['lug', 'lug', 'lug', 'ach', 'ach', 'ach',
+                            'eng', 'eng', 'eng', 'lug', 'lug', 'lug',
+                            'ach', 'ach', 'ach', 'eng', 'eng', 'eng'], 
+        'target_language': ['lug', 'ach', 'eng', 'lug', 'ach', 'eng',
+                            'lug', 'ach', 'eng', 'lug', 'ach', 'eng',
+                            'lug', 'ach', 'eng', 'lug', 'ach', 'eng']}
+      expected = pd.DataFrame(expected).to_dict(orient='records')
+      self.assertCountEqual(dataset, expected)
+      
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Utility for creating translation datasets from the new SALT format, catering for various cases including many-to-one, one-to-many and many-to-many translation.